### PR TITLE
Upgrade PyMongo to 4.10.1 for Python 3.14 compatibility

### DIFF
--- a/requirements/pkg.in
+++ b/requirements/pkg.in
@@ -2,6 +2,6 @@
 dnspython~=2.0
 marshmallow~=3.0
 mongoengine~=0.27
-PyMongo[srv]~=3.0
+PyMongo[srv]~=4.0
 sweetrpg-model-core
 sweetrpg-common

--- a/requirements/pkg.txt
+++ b/requirements/pkg.txt
@@ -16,7 +16,7 @@ mongoengine==0.29.3
     # via -r requirements/pkg.in
 packaging==26.3
     # via marshmallow
-pymongo[srv]==3.13.0
+pymongo[srv]==4.10.1
     # via
     #   -r requirements/pkg.in
     #   mongoengine

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         "dnspython~=2.0",
         "marshmallow~=3.0",
         "mongoengine~=0.27",
-        "PyMongo[srv]~=3.0",
+        "PyMongo[srv]~=4.0",
         "sweetrpg-model-core",
         "sweetrpg-common",
     ],


### PR DESCRIPTION
## Summary
PyMongo 3.x imports `MutableMapping` from the `collections` module, removed in Python 3.10. This breaks import on Python 3.14, the platform's required floor.

PyMongo 4.10.1 uses `collections.abc.MutableMapping` and is fully compatible with Python 3.12+. No code changes required - mongoengine abstracts PyMongo API details, so nothing in this repo depends on 3.x-specific behavior.

## Changes
- setup.py: PyMongo constraint bumped from `~=3.0` to `~=4.0`
- requirements/pkg.in: updated to match
- requirements/pkg.txt: locked to PyMongo 4.10.1

## Related
Same fix pattern as sweetrpg/client.py#103.