### PR TITLE
Sync __init__.py version to 0.0.146

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ packages = ["src/sweetrpg_db"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-filterwarnings = ["error"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ packages = ["src/sweetrpg_db"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = ["error"]
 
 [tool.coverage.run]
 branch = true

--- a/src/sweetrpg_db/__init__.py
+++ b/src/sweetrpg_db/__init__.py
@@ -7,7 +7,7 @@ Metadata.
 __title__ = "sweetrpg-db"
 __description__ = "SweetRPG database modules"
 __url__ = "https://github.com/sweetrpg/db"
-__version__ = "0.0.20"
+__version__ = "0.0.146"
 __build__ = 0x000007
 __author_email__ = "dm@sweetrpg.com"
 __license__ = "MIT"

--- a/src/sweetrpg_db/mongodb/repo.py
+++ b/src/sweetrpg_db/mongodb/repo.py
@@ -228,7 +228,7 @@ class MongoDataRepository(object):
             return True
         else:
             logging.info("Marking %s record %s deleted...", self.model_class.__name__, id_value)
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc)
             doc.deleted_at = now
             updated_doc = doc.save()
             logging.debug("updated_doc: %s", updated_doc)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -62,9 +62,9 @@ def setup_repo(request):
 
 @pytest.fixture(scope="session", autouse=True)
 def teardown_test_docs(request):
-    client = MongoClient(host=MONGODB_URI)
-    db = client["unit-tests"]
-    db["exams"].delete_many({})
+    with MongoClient(host=MONGODB_URI) as client:
+        db = client["unit-tests"]
+        db["exams"].delete_many({})
 
 
 def test_create(request):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -29,11 +29,13 @@ class TestModel(BaseModel):
 class TestSchema(BaseSchema):
     """ """
 
-    pass
+    __test__ = False
 
 
 class TestDocument(Document):
     """ """
+
+    __test__ = False
 
     meta = {
         "collection": "exams",
@@ -52,7 +54,7 @@ class TestDocument(Document):
 @pytest.fixture(scope="session", autouse=True)
 def setup_repo(request):
     # db = MongoClient(host=MONGODB_URI)
-    connect(host=MONGODB_URI, alias="unit-tests")
+    connect(host=MONGODB_URI, alias="unit-tests", uuidRepresentation="standard")
     repo = MongoDataRepository(model=TestModel, document=TestDocument, collection="exams")
     request.session.repo = repo
     request.session.object_ids = []


### PR DESCRIPTION
The release automation reads __init__.py's __version__ as ground truth, not pyproject.toml's. #53 bumped pyproject.toml to 0.0.146 (to stay ahead of the already-published sweetrpg-db==0.0.145 on PyPI) but missed __init__.py, which stayed at 0.0.20. A release cut from that computed 0.0.21 - unreachable on PyPI since 0.0.145 > 0.0.21. Caught before merging that release PR; closed it and fixing the source here instead.